### PR TITLE
Add reference to IMU Data article in the Open Ephys wiki repo

### DIFF
--- a/source/ucla-miniscope-v4/quick/tutorial.rst
+++ b/source/ucla-miniscope-v4/quick/tutorial.rst
@@ -39,12 +39,15 @@ Interact with the UCLA Miniscope v4 Through Bonsai
                         :align: center
                         :height: 400px
 
-    :Orientation Data:   Double left-click the ``Quaternion`` node. This displays a real-time visualization of quarternion data which represents the miniscope's orientation. Right-click the visualization, and left-click the drop-down menu. Set the value in the ``History Length`` field to 100. Reorient the UCLA Miniscope v4. Confirm the quarternion visualization responds accordingly:
+    :Orientation Data:   Double left-click the ``Quaternion`` node. This displays a real-time visualization of quaternion data which represents the miniscope's orientation. Right-click the visualization, and left-click the drop-down menu. Set the value in the ``History Length`` field to 100. Reorient the UCLA Miniscope v4. Confirm the quaternion visualization responds accordingly:
 
                         ..  image:: /_static/images/quarternion-demo.webp
                             :alt:   animation of demonstrating quaternion data
                             :align: center
                             :height: 400px
+
+                        To learn more about how to interpret quaternion data, visit the `IMU Data
+                        article <https://github.com/open-ephys/wiki/wiki/IMU-Data>`_ in the Open Ephys wiki repo.
 
     **UCLA Miniscope v4 Settings**
 


### PR DESCRIPTION
Jon suggests adding the mouse head demo for explaining IMU data, but I think that part we be added at a later date with the GUI, and that adding references to the IMU Data article suffices in the meanwhile.

Fix #37