### PR TITLE
fix banner

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -4,6 +4,6 @@
   {{ super() }}
 
   <div class="custom-announcement">
-    This documentation supports the latest <a href="Hardware-Guide/miniscope-daq/firmware-update.html">Miniscope DAQ firmware</a>, the latest <a href="https://github.com/open-ephys/bonsai-miniscope/releases">OpenEphys.Miniscope Bonsai package</a>, and Bonsai 2.9+.
+    This documentation supports the latest <a href="{{ pathto('Hardware-Guide/miniscope-daq/firmware-update') }}">Miniscope DAQ firmware</a>, the latest <a href="https://github.com/open-ephys/bonsai-miniscope/releases">OpenEphys.Miniscope Bonsai package</a>, and Bonsai 2.9+.
   </div>
 {% endblock %}

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -4,6 +4,6 @@
   {{ super() }}
 
   <div class="custom-announcement">
-    This documentation supports the latest <a href="firmware-update.html">Miniscope DAQ firmware</a>, the latest <a href="https://github.com/open-ephys/bonsai-miniscope/releases">OpenEphys.Miniscope Bonsai package</a>, and Bonsai 2.9+.
+    This documentation supports the latest <a href="Hardware-Guide/miniscope-daq/firmware-update.html">Miniscope DAQ firmware</a>, the latest <a href="https://github.com/open-ephys/bonsai-miniscope/releases">OpenEphys.Miniscope Bonsai package</a>, and Bonsai 2.9+.
   </div>
 {% endblock %}


### PR DESCRIPTION
The link was directing to https://open-ephys.github.io/miniscope-docs/firmware-update.html instead of the actual location. I think i've fixed it now.